### PR TITLE
remove deprecated attribute

### DIFF
--- a/bin/todoist
+++ b/bin/todoist
@@ -13,11 +13,8 @@ class TodoistCLI < Thor
     setup_todoist_base
 
     Todoist::Project.all.each do |project|
-      next if name and project.name !~ /#{name}/
-
-      if project.task_count > 0
-        print_project(project)
-      end
+      next unless (name and project.name =~ /#{name}/) || project.tasks.count > 0
+      print_project(project)
     end
   end
 

--- a/lib/todoist/project.rb
+++ b/lib/todoist/project.rb
@@ -49,7 +49,6 @@ module Todoist
       @color      = parameters['color']
       @collapsed  = parameters['collapsed']
       @order      = parameters['item_order']
-      @count      = parameters['cache_count']
       @indent     = parameters['indent']
     end
 
@@ -74,11 +73,12 @@ module Todoist
     ##
     # The task count
     #
-    # The number of tasks a project has, according to its cache_count when it was fetched
+    # The number of tasks a project has
     #
     # @return [Integer] The number of tasks this project has
     def task_count
-      @count
+      @all_tasks ||= Task.all(self)
+      @all_tasks.size
     end
 
     ##
@@ -86,7 +86,7 @@ module Todoist
     #
     # @return [Array] An Array of Todoist::Tasks
     def tasks
-      Task.uncompleted(self)
+      @uncompleted_tasks ||= Task.uncompleted(self)
     end
 
     ##
@@ -94,7 +94,7 @@ module Todoist
     #
     # @return [Array] An Array of completed Todoist::Tasks
     def completed_tasks
-      Task.completed(self)
+      @completed_tasks ||= Task.completed(self)
     end
 
     ##


### PR DESCRIPTION
cache_count is deprecated attribute.

http://todoist.com/API/help/standard#projects

I couldn't get it as hoped for.(But I don't know whether or not to be caused by this...)

In either case, I think you shouldn't use this attribute so this is deprecated.
